### PR TITLE
[wink] Rebase to remove all the version bump noise and add generic lock support

### DIFF
--- a/addons/binding/org.openhab.binding.wink/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.wink/ESH-INF/thing/thing-types.xml
@@ -54,6 +54,20 @@
                 <required>true</required></parameter>
             <parameter name="device_config_string" type="text" required="true"></parameter></config-description>
     </thing-type>
+    <thing-type id="lock">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="wink_hub_2"/>
+        </supported-bridge-type-refs>
+        <label>Lock</label>
+        <description>Generic Connected Lock</description>
+        <channels>
+            <channel typeId="lockState" id="lockstate" />
+        </channels>
+       <config-description>
+            <parameter name="device_id" type="text">
+                <required>true</required></parameter>
+       </config-description>        
+    </thing-type>
     <channel-type id="lightDimmer">
         <item-type>Dimmer</item-type>
         <label>Light Level</label>
@@ -67,6 +81,12 @@
         <description>The switch channel allows to switch the light on and off.
         </description>
         <category>Light</category>
+    </channel-type>
+    <channel-type id="lockState">
+        <item-type>Switch</item-type>
+        <label>Lock State</label>
+        <description>The Lock State</description>
+        <category>Lock</category>
     </channel-type>
 
 </thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.wink/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.openhab.binding.wink/ESH-INF/thing/thing-types.xml
@@ -64,8 +64,8 @@
             <channel typeId="lockState" id="lockstate" />
         </channels>
        <config-description>
-            <parameter name="device_id" type="text">
-                <required>true</required></parameter>
+            <parameter name="device_id" type="text" required="true" />
+            <parameter name="device_config_string" type="text" required="true" />
        </config-description>        
     </thing-type>
     <channel-type id="lightDimmer">

--- a/addons/binding/org.openhab.binding.wink/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.wink/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Wink Binding
 Bundle-SymbolicName: org.openhab.binding.wink;singleton:=true
 Bundle-Vendor: openHAB
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.2.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .,
  lib/pubnub-gson-4.4.3-all.jar

--- a/addons/binding/org.openhab.binding.wink/pom.xml
+++ b/addons/binding/org.openhab.binding.wink/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.openhab.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.openhab.binding</groupId>

--- a/addons/binding/org.openhab.binding.wink/pom.xml
+++ b/addons/binding/org.openhab.binding.wink/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.openhab.binding</groupId>
   <artifactId>org.openhab.binding.wink</artifactId>
-  <version>2.1.0-SNAPSHOT</version>
+  <version>2.2.0-SNAPSHOT</version>
 
   <name>Wink Binding</name>
   <packaging>eclipse-plugin</packaging>

--- a/addons/binding/org.openhab.binding.wink/pom.xml
+++ b/addons/binding/org.openhab.binding.wink/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>org.openhab.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.openhab.binding</groupId>
   <artifactId>org.openhab.binding.wink</artifactId>
-  <version>2.2.0-SNAPSHOT</version>
+  <version>2.1.0-SNAPSHOT</version>
 
   <name>Wink Binding</name>
   <packaging>eclipse-plugin</packaging>

--- a/addons/binding/org.openhab.binding.wink/src/main/java/org/openhab/binding/wink/WinkBindingConstants.java
+++ b/addons/binding/org.openhab.binding.wink/src/main/java/org/openhab/binding/wink/WinkBindingConstants.java
@@ -24,10 +24,12 @@ public class WinkBindingConstants {
     public final static ThingTypeUID THING_TYPE_LIGHT_BULB = new ThingTypeUID(BINDING_ID, "light_bulb");
     public final static ThingTypeUID THING_TYPE_REMOTE = new ThingTypeUID(BINDING_ID, "remote");
     public final static ThingTypeUID THING_TYPE_BINARY_SWITCH = new ThingTypeUID(BINDING_ID, "binary_switch");
+    public final static ThingTypeUID THING_TYPE_LOCK = new ThingTypeUID(BINDING_ID, "lock");
 
     // List of all Channel ids for a light bulb
     public final static String CHANNEL_LIGHTLEVEL = "lightlevel";
     public final static String CHANNEL_SWITCHSTATE = "switchstate";
+    public final static String CHANNEL_LOCKSTATE = "lockstate";
 
     // REST URI constants
     public static final String WINK_URI = "https://api.wink.com/";

--- a/addons/binding/org.openhab.binding.wink/src/main/java/org/openhab/binding/wink/handler/LockHandler.java
+++ b/addons/binding/org.openhab.binding.wink/src/main/java/org/openhab/binding/wink/handler/LockHandler.java
@@ -1,0 +1,91 @@
+package org.openhab.binding.wink.handler;
+
+import static org.openhab.binding.wink.WinkBindingConstants.CHANNEL_LOCKSTATE;
+
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
+import org.eclipse.smarthome.core.types.State;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+public class LockHandler extends WinkHandler {
+
+    public LockHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if (channelUID.getId().equals(CHANNEL_LOCKSTATE)) {
+            if (command.equals(OnOffType.ON)) {
+                setLock(true);
+            } else if (command.equals(OnOffType.OFF)) {
+                setLock(false);
+            } else if (command instanceof RefreshType) {
+                logger.debug("Refreshing state");
+                ReadDeviceState();
+            }
+        }
+    }
+
+    private void setLock(boolean lock) {
+        if (lock) {
+            sendCommand("{\"desired_state\": {\"locked\": true}}");
+        } else {
+            sendCommand("{\"desired_state\": {\"locked\": false}}");
+        }
+    }
+
+    @Override
+    protected String getDeviceRequestPath() {
+        return "locks/" + this.deviceConfig.getDeviceId();
+    }
+
+    @Override
+    protected void updateDeviceStateCallback(JsonObject jsonDataBlob) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void sendCommandCallback(JsonObject jsonResult) {
+        updateState(jsonResult);
+    }
+
+    @Override
+    protected void pubNubMessageCallback(JsonObject jsonDataBlob) {
+        updateState(jsonDataBlob);
+    }
+
+    private void updateState(JsonObject jsonDataBlob) {
+        boolean lockedStateLastReading = false;
+        JsonElement lastReadingBlob = jsonDataBlob.get("last_reading");
+        if (lastReadingBlob != null) {
+            JsonElement lockedStateBlob = lastReadingBlob.getAsJsonObject().get("locked");
+            if (lockedStateBlob != null) {
+                lockedStateLastReading = lockedStateBlob.getAsBoolean();
+            }
+        }
+        boolean lockedDesiredState = false;
+        JsonElement desiredStateBlob = jsonDataBlob.get("desired_state");
+        if (desiredStateBlob != null) {
+            JsonElement lockedBlob = desiredStateBlob.getAsJsonObject().get("locked");
+            if (lockedBlob != null) {
+                lockedDesiredState = lockedBlob.getAsBoolean();
+            }
+        }
+        // Don't update the state during a transition.
+        if (lockedDesiredState == lockedStateLastReading) {
+            State state = OnOffType.OFF;
+            if (lockedStateLastReading) {
+                state = OnOffType.ON;
+            }
+            updateState(CHANNEL_LOCKSTATE, state);
+        }
+    }
+
+}

--- a/addons/binding/org.openhab.binding.wink/src/main/java/org/openhab/binding/wink/handler/LockHandler.java
+++ b/addons/binding/org.openhab.binding.wink/src/main/java/org/openhab/binding/wink/handler/LockHandler.java
@@ -47,13 +47,11 @@ public class LockHandler extends WinkHandler {
 
     @Override
     protected void updateDeviceStateCallback(JsonObject jsonDataBlob) {
-        // TODO Auto-generated method stub
-
+        updateState(jsonDataBlob);
     }
 
     @Override
     public void sendCommandCallback(JsonObject jsonResult) {
-        updateState(jsonResult);
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.wink/src/main/java/org/openhab/binding/wink/handler/LockHandler.java
+++ b/addons/binding/org.openhab.binding.wink/src/main/java/org/openhab/binding/wink/handler/LockHandler.java
@@ -5,6 +5,8 @@ import static org.openhab.binding.wink.WinkBindingConstants.CHANNEL_LOCKSTATE;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
@@ -16,6 +18,22 @@ public class LockHandler extends WinkHandler {
 
     public LockHandler(Thing thing) {
         super(thing);
+    }
+
+    @Override
+    public void initialize() {
+        if (!this.deviceConfig.validateConfig()) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Invalid config.");
+            return;
+        }
+        updateStatus(ThingStatus.ONLINE);
+    }
+
+    @Override
+    public void channelLinked(ChannelUID channelUID) {
+        if (channelUID.getId().equals(CHANNEL_LOCKSTATE)) {
+            ReadDeviceState();
+        }
     }
 
     @Override

--- a/addons/binding/org.openhab.binding.wink/src/main/java/org/openhab/binding/wink/internal/WinkHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.wink/src/main/java/org/openhab/binding/wink/internal/WinkHandlerFactory.java
@@ -17,10 +17,11 @@ import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.openhab.binding.wink.handler.BinarySwitchHandler;
 import org.openhab.binding.wink.handler.LightBulbHandler;
+import org.openhab.binding.wink.handler.LockHandler;
 import org.openhab.binding.wink.handler.RemoteHandler;
 import org.openhab.binding.wink.handler.WinkHub2Handler;
-import org.openhab.binding.wink.handler.BinarySwitchHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +38,7 @@ public class WinkHandlerFactory extends BaseThingHandlerFactory {
     private Logger logger = LoggerFactory.getLogger(WinkHandlerFactory.class);
 
     public final static Set<ThingTypeUID> DISCOVERABLE_DEVICE_TYPES_UIDS = ImmutableSet.of(THING_TYPE_LIGHT_BULB,
-            THING_TYPE_REMOTE, THING_TYPE_BINARY_SWITCH);
+            THING_TYPE_REMOTE, THING_TYPE_BINARY_SWITCH, THING_TYPE_LOCK);
 
     private final static Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = ImmutableSet.of(THING_TYPE_WINK_HUB_2);
 
@@ -60,6 +61,8 @@ public class WinkHandlerFactory extends BaseThingHandlerFactory {
             return new RemoteHandler(thing);
         } else if (thingTypeUID.equals(THING_TYPE_BINARY_SWITCH)) {
             return new BinarySwitchHandler(thing);
+        } else if (thingTypeUID.equals(THING_TYPE_LOCK)) {
+            return new LockHandler(thing);
         }
 
         return null;

--- a/addons/binding/org.openhab.binding.wink/src/main/java/org/openhab/binding/wink/internal/discovery/WinkDeviceDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.wink/src/main/java/org/openhab/binding/wink/internal/discovery/WinkDeviceDiscoveryService.java
@@ -99,6 +99,8 @@ public class WinkDeviceDiscoveryService extends AbstractDiscoveryService {
                 addWinkDevice(THING_TYPE_REMOTE, element.getAsJsonObject(), "remote_id");
             } else if (element.getAsJsonObject().get("binary_switch_id") != null) {
                 addWinkDevice(THING_TYPE_BINARY_SWITCH, element.getAsJsonObject(), "binary_switch_id");
+            } else if (element.getAsJsonObject().get("lock_id") != null) {
+                addWinkDevice(THING_TYPE_LOCK, element.getAsJsonObject(), "lock_id");
             }
         }
     }


### PR DESCRIPTION
Removed all the noise from the previous pull request. (version bumps from the main repo).

This commit provides basic support for generic locks on the wink hub as a switch item.  The handler simply sets the lockstate to on or off depending on the locked or unlocked state.