### PR TITLE
fixed duplicate statuses during lock state transition

### DIFF
--- a/addons/binding/org.openhab.binding.wink/src/main/java/org/openhab/binding/wink/handler/LockHandler.java
+++ b/addons/binding/org.openhab.binding.wink/src/main/java/org/openhab/binding/wink/handler/LockHandler.java
@@ -61,12 +61,16 @@ public class LockHandler extends WinkBaseThingHandler {
 
     @Override
     protected void updateDeviceState(IWinkDevice device) {
-        if (device.getCurrentState().get("locked").equals("true")) {
-            logger.debug("LOCKSTATE is ON");
-            updateState(CHANNEL_LOCKSTATE, OnOffType.ON);
-        } else {
-            logger.debug("LOCKSTATE is OFF");
-            updateState(CHANNEL_LOCKSTATE, OnOffType.OFF);
+        String desired = device.getDesiredState().get("locked");
+        String current = device.getCurrentState().get("locked");
+        if (desired == null || desired.equals(current)) {
+            if (current.equals("true")) {
+                logger.debug("LOCKSTATE is ON");
+                updateState(CHANNEL_LOCKSTATE, OnOffType.ON);
+            } else {
+                logger.debug("LOCKSTATE is OFF");
+                updateState(CHANNEL_LOCKSTATE, OnOffType.OFF);
+            }
         }
     }
 


### PR DESCRIPTION
There was just some noise when transitioning lock state that I wanted to clean up.